### PR TITLE
docs: 修复 README 无法显示的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ Demo仅作展示用，部分功能受Web限制，并非完整版。Demo可能更
 
 <a href="https://github.com/GhostenEditor/Ghosten-Player">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GhostenEditor/Ghosten-Player&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=GhostenEditor/Ghosten-Player&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />
  </picture>
 </a>
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -184,9 +184,9 @@ If you find this project useful, consider buying me a ☕ **coffee** to keep the
 
 <a href="https://github.com/GhostenEditor/Ghosten-Player">  
  <picture>  
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=GhostenEditor/Ghosten-Player&type=Date&theme=dark" />  
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />  
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />  
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=GhostenEditor/Ghosten-Player&type=Date&theme=dark" />  
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />  
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=GhostenEditor/Ghosten-Player&type=Date" />  
  </picture>  
 </a>  
 


### PR DESCRIPTION
当前 README 中的 Star History 图表（star-history.com）已经损坏，无法正常加载，原因是 GitHub stargazer API 的限制。本次改动将图表链接切换到可用的新地址（star-history.dera.page），确保贡献者能正常查看项目星标趋势。